### PR TITLE
Add `--name-only` option to show subcommand

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,24 +1,19 @@
 name: Check
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: push
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        components: rustfmt, clippy
-    - name: Check
-      run: cargo check --verbose
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: Check
+        run: cargo check --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,236 @@
 version = 3
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "clap"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "gh-default-branch"
 version = "0.1.0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "gh-default-branch"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+description = "GitHub CLI extension to show & rename the default branch"
 edition = "2021"
 name = "gh-default-branch"
 version = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = {version = "3.1.18", features = ["derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "gh-default-branch"
-version = "0.1.0"
+version = "0.6.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -33,16 +33,56 @@ $ gh extension install daido1976/gh-default-branch
 
 ```sh
 $ gh default-branch -h
-# Usage: gh default-branch
+# gh default-branch 0.6.0
+# GitHub CLI extension to show & rename the default branch
 #
+# USAGE:
+#     gh-default-branch <SUBCOMMAND>
+#
+# OPTIONS:
+#     -h, --help       Print help information
+#     -V, --version    Print version information
+#
+# SUBCOMMANDS:
+#     help      Print this message or the help of the given subcommand(s)
+#     rename    Rename default branch
+#     show      Show default branch
+
+$ gh default-branch show -h
+# gh-default-branch-show
 # Show default branch
-# $ gh default-branch show
 #
+# USAGE:
+#     gh-default-branch show [OPTIONS]
+#
+# OPTIONS:
+#     -h, --help         Print help information
+#     -n, --name-only    Show only the branch name (e.g. main)
+
+$ gh default-branch rename -h
+# gh-default-branch-rename
 # Rename default branch
-# $ gh default-branch rename <name>
+#
+# USAGE:
+#     gh-default-branch rename <NAME>
+#
+# ARGS:
+#     <NAME>
+#
+# OPTIONS:
+#     -h, --help    Print help information
 ```
 
-## Release
+## Development
+
+### Debug
+
+```sh
+$ gh extension install .
+$ gh default-branch <SUBCOMMAND>
+```
+
+### Release
 
 This extension is released as a precompiled extension.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ $ gh default-branch -h
 
 ## Release
 
+This extension is released as a precompiled extension.
+
+See. https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions#creating-a-precompiled-extension-manually
+
 ```sh
 $ git tag <version(e.g.`v0.1`)>
 $ git push --tag

--- a/gh-default-branch
+++ b/gh-default-branch
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# for debug
+cargo build --release
+target/release/gh-default-branch "$@"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,9 +1,13 @@
 use std::process::{Command, Output};
 
-pub fn show() {
+pub fn show(name_only: bool) {
     let repo_name_with_owner = get_repo_name_with_owner();
     let default_branch = get_default_branch(&repo_name_with_owner);
-    println!("Current default branch is \"{}\"", default_branch,);
+    if name_only {
+        println!("{}", default_branch)
+    } else {
+        println!("Current default branch is \"{}\"", default_branch);
+    }
 }
 
 // TODO: Make it interactive because this is a command with a lot of side effects.

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -26,16 +26,6 @@ pub fn rename(to_branch: &str) {
     );
 }
 
-pub fn help() {
-    println!(
-        "Usage: gh default-branch\n\n\
-        Show default branch\n\
-        $ gh default-branch show\n\n\
-        Rename default branch\n\
-        $ gh default-branch rename <name>"
-    );
-}
-
 /// e.g. daido1976/gh-default-branch
 fn get_repo_name_with_owner() -> String {
     // gh repo view --json nameWithOwner --jq .nameWithOwner

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ enum Commands {
     Show {
         /// Show only the branch name (e.g. main)
         #[clap(short, long)]
-        name: bool,
+        name_only: bool,
     },
     /// Rename default branch
     #[clap(arg_required_else_help = true)]
@@ -23,15 +23,11 @@ enum Commands {
 }
 
 fn main() {
-    run()
-}
-
-fn run() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Show { name } => {
-            cmd::show(name);
+        Commands::Show { name_only } => {
+            cmd::show(name_only);
         }
         Commands::Rename { name } => cmd::rename(&name),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,7 @@ mod cmd;
 use clap::{Parser, Subcommand};
 
 #[derive(Debug, Parser)]
-#[clap(name = "gh default-branch", version)]
-#[clap(about = "GitHub CLI extension to show & rename the default branch", long_about = None)]
+#[clap(name = "gh default-branch", version, about, long_about = None)]
 struct Cli {
     #[clap(subcommand)]
     command: Commands,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,38 @@
 mod cmd;
-use std::env;
+use clap::{Parser, Subcommand};
 
-fn main() {
-    let args: Vec<String> = env::args().collect();
-    run(args)
+#[derive(Debug, Parser)]
+#[clap(name = "gh default-branch")]
+#[clap(about = "GitHub CLI extension to show & rename the default branch", long_about = None)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
 }
 
-fn run(args: Vec<String>) {
-    match args.get(1) {
-        Some(first) if first == "show" => cmd::show(),
-        Some(first) if first == "rename" => {
-            if let Some(to_name) = args.get(2) {
-                cmd::rename(to_name)
-            } else {
-                println!("USAGE: 'gh default-branch rename <name>' Please specify the name.")
-            }
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Show default branch
+    Show {
+        /// Show only the branch name (e.g. main)
+        #[clap(short, long)]
+        name: bool,
+    },
+    /// Rename default branch
+    #[clap(arg_required_else_help = true)]
+    Rename { name: String },
+}
+
+fn main() {
+    run()
+}
+
+fn run() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Show { name } => {
+            cmd::show();
         }
-        // when passed no args, or the wrong args.
-        _ => cmd::help(),
+        Commands::Rename { name } => cmd::rename(&name),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn run() {
 
     match cli.command {
         Commands::Show { name } => {
-            cmd::show();
+            cmd::show(name);
         }
         Commands::Rename { name } => cmd::rename(&name),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod cmd;
 use clap::{Parser, Subcommand};
 
 #[derive(Debug, Parser)]
-#[clap(name = "gh default-branch")]
+#[clap(name = "gh default-branch", version)]
 #[clap(about = "GitHub CLI extension to show & rename the default branch", long_about = None)]
 struct Cli {
     #[clap(subcommand)]


### PR DESCRIPTION
## Why

See. https://github.com/daido1976/gh-default-branch/issues/5

## How

- Introduce [clap](https://github.com/clap-rs/clap)
- Add `--name-only` option to show subcommand

The output is as follows.

```sh
$ gh default-branch -h
gh default-branch 0.6.0
GitHub CLI extension to show & rename the default branch

USAGE:
    gh-default-branch <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    help      Print this message or the help of the given subcommand(s)
    rename    Rename default branch
    show      Show default branch

$ gh default-branch show -h
gh-default-branch-show
Show default branch

USAGE:
    gh-default-branch show [OPTIONS]

OPTIONS:
    -h, --help         Print help information
    -n, --name-only    Show only the branch name (e.g. main)

$ gh default-branch show
    Finished release [optimized] target(s) in 0.03s
Current default branch is "main"

$ gh default-branch show -n
main

$ gh default-branch show --name-only
main
```

## Note

- https://github.com/clap-rs/clap/blob/v3.1.18/examples/tutorial_derive/README.md